### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "debug": "2.6.8",
     "ejs": "^2.5.6",
     "hoek": "^4.0.0",
-    "npm": "^6.4.1",
     "streaming-json-stringify": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION

Hello GhaffarElahi!

It seems like you have npm as one of your (dev-) dependency in security-on-github.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
